### PR TITLE
docs: expand knowledgebase (CS, langs, systems, devops, data, craft, advanced)

### DIFF
--- a/ultimate_coder/docs/resources.md
+++ b/ultimate_coder/docs/resources.md
@@ -1,15 +1,13 @@
 # Resources
 
-## Books
-- Clean Code
-- DDIA
-- SICP
+A curated knowledgebase lives in [../resources/knowledgebase.yaml](../resources/knowledgebase.yaml).
 
-## Katas
-- Advent of Code
-- Codewars
+## Categories
 
-## Tooling
-- formatters
-- linters
-- Mermaid
+- **CS** – foundations of computer science.
+- **Languages** – programming language guides and references.
+- **Systems** – operating systems and infrastructure.
+- **DevOps** – automation, deployment, and operations.
+- **Data** – data engineering and management.
+- **Craft** – software design and craftsmanship.
+- **Advanced** – specialized or in-depth topics.

--- a/ultimate_coder/resources/knowledgebase.yaml
+++ b/ultimate_coder/resources/knowledgebase.yaml
@@ -1,0 +1,28 @@
+cs:
+  - title: "Structure and Interpretation of Computer Programs"
+    link: "https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/"
+    note: "Foundational CS concepts via Scheme."
+languages:
+  - title: "Python Official Docs"
+    link: "https://docs.python.org/3/"
+    note: "Comprehensive guide to Python."
+systems:
+  - title: "Operating Systems: Three Easy Pieces"
+    link: "https://pages.cs.wisc.edu/~remzi/OSTEP/"
+    note: "Free textbook on OS principles."
+devops:
+  - title: "Kubernetes Documentation"
+    link: "https://kubernetes.io/docs/home/"
+    note: "Container orchestration and cluster management."
+data:
+  - title: "Designing Data-Intensive Applications"
+    link: "https://dataintensive.net/"
+    note: "Patterns for scalable data systems."
+craft:
+  - title: "Clean Code"
+    link: "https://www.informit.com/articles/article.aspx?p=1216151"
+    note: "Guidelines for writing clean, maintainable code."
+advanced:
+  - title: "Distributed Systems For Fun and Profit"
+    link: "http://book.mixu.net/distsys/"
+    note: "Approachable guide to distributed systems."


### PR DESCRIPTION
## Summary
- add consolidated `knowledgebase.yaml` with CS, languages, systems, devops, data, craft, and advanced entries
- rewrite `docs/resources.md` to reference the YAML and list the new categories

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbff1379e48324b0993b858a973c6d