### PR TITLE
Add Streamlit GUI for browsing tracks and knowledgebase

### DIFF
--- a/.github/workflows/validate-knowledgebase.yml
+++ b/.github/workflows/validate-knowledgebase.yml
@@ -1,5 +1,5 @@
 ---
-name: Validate Knowledgebase
+name: Validate YAML
 
 on:
   pull_request:
@@ -16,5 +16,5 @@ jobs:
           python-version: '3.x'
       - name: Install yamllint
         run: pip install yamllint
-      - name: Validate knowledgebase.yaml
-        run: yamllint ultimate_coder/resources/knowledgebase.yaml
+      - name: Validate YAML files
+        run: yamllint Codertext.yaml.txt ultimate_coder/resources/knowledgebase.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local UI state
+ui/progress.json

--- a/Codertext.yaml.txt
+++ b/Codertext.yaml.txt
@@ -1,0 +1,91 @@
+ultimate_coder:
+  meta:
+    version: 1.0
+    owner: "YOUR_NAME"
+    cadence: weekly_sprints
+    duration_weeks: 26
+    levels: [Novice, Apprentice, Journeyman, Senior, Principal]
+    hours_per_week: 12-20
+    philosophy: ["Learn by building", "Feedback loops", "Depth→breadth"]
+    ethics: ["Privacy-by-design", "Security-first", "License compliance"]
+  prerequisites:
+    skills: ["Shell + editor", "Algebra + logic"]
+    env:
+      os: [Linux, macOS, WSL2]
+      tools:
+        - {name: Python, ver: "3.13", local_pkg: "/mnt/data/python-3.13.7-macos11.pkg"}
+        - {name: OpenJDK, ver: "26-ea", local_tar: "/mnt/data/openjdk-26-ea+14_linux-x64_bin.tar.gz"}
+        - {name: Editor, opts: ["VSCode", "NPP"], npp_zip: "/mnt/data/npp.8.8.5.portable.x64.zip"}
+        - {name: Ghidra, opt: true, zip: "/mnt/data/ghidra-master.zip"}
+  outcomes:
+    core: ["Code in 2+ langs", "Build APIs/services", "Algo reasoning", "Ship w/ CI/CD", "AI-assisted dev"]
+    artifacts: ["Portfolio repo", "Tech notes", "3 showcase projects"]
+  tracks:
+    - id: cs
+      title: CS Fundamentals
+      modules:
+        - {name: "DS & Complexity", weeks: 2, skills: [Big-O, graphs], proj: "Implement DS + BFS/DFS", resources: [cs_fundamentals]}
+        - {name: "Algorithms", weeks: 2, skills: [sort, DP], proj: "Schedule optimizer", resources: [algorithms]}
+    - id: langs
+      title: Language Mastery
+      modules:
+        - {name: "Python Deep Dive", weeks: 2, proj: "CLI data tool", resources: [languages.python]}
+        - {name: "Systems Lang", weeks: 3, opts: [Rust, Go, Java], proj: "Perf service", resources: [languages.systems_lang]}
+    - id: systems
+      title: Systems & Arch
+      modules:
+        - {name: "APIs", weeks: 2, proj: "Prod REST API", resources: [systems.apis]}
+        - {name: "Perf/Obs", weeks: 2, proj: "Profile + fix bottlenecks", resources: [systems.perf_obs]}
+    - id: devops
+      title: DevOps
+      modules:
+        - {name: "Git→CI/CD", weeks: 1, resources: [devops.git_ci_cd]}
+        - {name: "Containers", weeks: 2, proj: "Blue/green deploy", resources: [devops.containers]}
+    - id: data_ai
+      title: Data & AI
+      modules:
+        - {name: "Data Pipes", weeks: 1, resources: [data_ai.data_pipes]}
+        - {name: "ML", weeks: 2, proj: "Tabular model", resources: [data_ai.ml]}
+        - {name: "AI-in-loop", weeks: 1, resources: [data_ai.ai_in_loop]}
+  sprints: {d1: plan, d2_3: build, d4: harden, d5: review}
+  assessments:
+    apprentice: ["Algo proj ≥80", "Python proj typed + 90% tests"]
+    journeyman: ["Service w/ CI/CD", "Threat model fixed"]
+    senior: ["Lead 2w team proj", "Deliver tech talk"]
+  capstones:
+    - {name: Full-stack, brief: "API+worker+UI w/ SLOs"}
+    - {name: AI Toolkit, brief: "CLI/VSCode ext for tests+perf"}
+  resources:
+    books: ["SICP", "DDIA", "Clean Code"]
+    katas: ["Advent of Code", "Codewars"]
+    tooling: ["linters", "formatters", "Mermaid"]
+    cs_fundamentals: ["CS50", "Grokking Algorithms"]
+    algorithms: ["CLRS", "AlgoExpert"]
+    languages:
+      python: ["Official Python Tutorial", "Fluent Python"]
+      systems_lang: ["Rust Book", "The Go Programming Language"]
+    systems:
+      apis: ["RESTful API Design", "APIs You Won't Hate"]
+      perf_obs: ["Systems Performance", "Distributed Tracing"]
+    devops:
+      git_ci_cd: ["Pro Git", "CI/CD Best Practices"]
+      containers: ["Docker Docs", "Kubernetes Basics"]
+    data_ai:
+      data_pipes: ["Data Engineering on Azure", "Airflow Docs"]
+      ml: ["scikit-learn Guide", "Hands-On ML"]
+      ai_in_loop: ["Human-in-the-Loop AI", "AI Safety Handbook"]
+    cs_fundamentals: ["SICP", "CS:APP"]
+    languages:
+      python: ["Fluent Python"]
+      rust: ["The Rust Programming Language"]
+      go: ["The Go Programming Language"]
+      java: ["Effective Java"]
+    systems_architecture: ["Designing Data-Intensive Applications", "Clean Architecture"]
+    devops: ["The Phoenix Project", "Kubernetes Up & Running"]
+    data_ai: ["Hands-On Machine Learning", "Deep Learning"]
+    craft_career: ["Clean Code", "The Pragmatic Programmer"]
+    advanced_optional:
+      reverse_engineering: ["Practical Reverse Engineering"]
+      graphics_simulation: ["Real-Time Rendering"]
+      security: ["Web Application Hacker's Handbook"]
+

--- a/Codertext.yaml.txt
+++ b/Codertext.yaml.txt
@@ -1,53 +1,78 @@
+---
 ultimate_coder:
   meta:
     version: 1.0
     owner: "YOUR_NAME"
     cadence: weekly_sprints
     duration_weeks: 26
-    levels: [Novice, Apprentice, Journeyman, Senior, Principal]
+    levels: [Novice, Apprentice, Journeyman, 
+		Senior, Principal]
     hours_per_week: 12-20
-    philosophy: ["Learn by building", "Feedback loops", "Depth→breadth"]
-    ethics: ["Privacy-by-design", "Security-first", "License compliance"]
+    philosophy: ["Learn by building",
+		 "Feedback loops", "Depth→breadth"]
+    ethics: ["Privacy-by-design",
+		 "Security-first", "License compliance"]
   prerequisites:
-    skills: ["Shell + editor", "Algebra + logic"]
+    skills: ["Shell + editor",
+		 "Algebra + logic"]
     env:
       os: [Linux, macOS, WSL2]
       tools:
-        - {name: Python, ver: "3.13", local_pkg: "/mnt/data/python-3.13.7-macos11.pkg"}
-        - {name: OpenJDK, ver: "26-ea", local_tar: "/mnt/data/openjdk-26-ea+14_linux-x64_bin.tar.gz"}
-        - {name: Editor, opts: ["VSCode", "NPP"], npp_zip: "/mnt/data/npp.8.8.5.portable.x64.zip"}
-        - {name: Ghidra, opt: true, zip: "/mnt/data/ghidra-master.zip"}
+        - {name: Python, ver: "3.13", 
+				local_pkg: "/mnt/data/python-3.13.7-macos11.pkg"}
+        - {name: OpenJDK, ver: "26-ea", 
+				local_tar: "/mnt/data/openjdk-26-ea+14_linux-x64_bin.tar.gz"}
+        - {name: Editor, opts: ["VSCode", "NPP"], 
+				npp_zip: "/mnt/data/npp.8.8.5.portable.x64.zip"}
+        - {name: Ghidra, opt: true, zip:
+				 "/mnt/data/ghidra-master.zip"}
   outcomes:
-    core: ["Code in 2+ langs", "Build APIs/services", "Algo reasoning", "Ship w/ CI/CD", "AI-assisted dev"]
+    core: ["Code in 2+ langs", 
+		"Build APIs/services", "Algo reasoning",
+		 "Ship w/ CI/CD", "AI-assisted dev"]
     artifacts: ["Portfolio repo", "Tech notes", "3 showcase projects"]
   tracks:
     - id: cs
       title: CS Fundamentals
       modules:
-        - {name: "DS & Complexity", weeks: 2, skills: [Big-O, graphs], proj: "Implement DS + BFS/DFS", resources: [cs_fundamentals]}
-        - {name: "Algorithms", weeks: 2, skills: [sort, DP], proj: "Schedule optimizer", resources: [algorithms]}
+        - {name: "DS & Complexity", 
+				weeks: 2, skills: [Big-O, graphs], proj: "Implement DS + BFS/DFS", resources: [cs_fundamentals]}
+        - {name: "Algorithms", weeks: 2, 
+				skills: [sort, DP], proj: "Schedule optimizer", 
+				resources: [algorithms]}
     - id: langs
       title: Language Mastery
       modules:
-        - {name: "Python Deep Dive", weeks: 2, proj: "CLI data tool", resources: [languages.python]}
-        - {name: "Systems Lang", weeks: 3, opts: [Rust, Go, Java], proj: "Perf service", resources: [languages.systems_lang]}
+        - {name: "Python Deep Dive", 
+				weeks: 2, proj: "CLI data tool", 
+				resources: [languages.python]}
+        - {name: "Systems Lang", weeks: 3, 
+				opts: [Rust, Go, Java], proj: "Perf service", 
+				resources: [languages.systems_lang]}
     - id: systems
       title: Systems & Arch
       modules:
-        - {name: "APIs", weeks: 2, proj: "Prod REST API", resources: [systems.apis]}
+        - {name: "APIs", weeks: 2, proj:
+				 "Prod REST API", resources: [systems.apis]}
         - {name: "Perf/Obs", weeks: 2, proj: "Profile + fix bottlenecks", resources: [systems.perf_obs]}
     - id: devops
       title: DevOps
       modules:
-        - {name: "Git→CI/CD", weeks: 1, resources: [devops.git_ci_cd]}
-        - {name: "Containers", weeks: 2, proj: "Blue/green deploy", resources: [devops.containers]}
+        - {name: "Git→CI/CD", weeks: 1, 
+				resources: [devops.git_ci_cd]}
+        - {name: "Containers", weeks: 2, 
+				proj: "Blue/green deploy", resources: [devops.containers]}
     - id: data_ai
       title: Data & AI
       modules:
-        - {name: "Data Pipes", weeks: 1, resources: [data_ai.data_pipes]}
-        - {name: "ML", weeks: 2, proj: "Tabular model", resources: [data_ai.ml]}
-        - {name: "AI-in-loop", weeks: 1, resources: [data_ai.ai_in_loop]}
-  sprints: {d1: plan, d2_3: build, d4: harden, d5: review}
+        - {name: "Data Pipes", weeks: 1, 
+				resources: [data_ai.data_pipes]}
+        - {name: "ML", weeks: 2, 
+				proj: "Tabular model", resources: [data_ai.ml]}
+        - {name: "AI-in-loop", weeks: 1, 
+				resources: [data_ai.ai_in_loop]}
+  sprints: {d1: plan, d2_3: build, 
+	d4: harden, d5: review}
   assessments:
     apprentice: ["Algo proj ≥80", "Python proj typed + 90% tests"]
     journeyman: ["Service w/ CI/CD", "Threat model fixed"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: gui
+
+gui:
+	pip install -r requirements.txt && streamlit run ui/app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.36
+pyyaml>=6.0

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,167 @@
+import json, os, re, webbrowser
+from pathlib import Path
+
+import streamlit as st
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC_PATH = ROOT / "Codertext.yaml.txt"
+KB_PATH   = ROOT / "ultimate_coder" / "resources" / "knowledgebase.yaml"
+STATE_DIR = ROOT / "ui"
+STATE_PATH = STATE_DIR / "progress.json"
+
+# ---------- helpers ----------
+def load_yaml(p: Path, default=None):
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return default
+
+def save_json(p: Path, data: dict):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+def load_state():
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text("utf-8"))
+        except Exception:
+            pass
+    return {"completed": {}, "notes": {}}
+
+def set_completed(state: dict, module_key: str, done: bool):
+    state["completed"][module_key] = bool(done)
+    save_json(STATE_PATH, state)
+
+def set_note(state: dict, module_key: str, note: str):
+    state["notes"][module_key] = note
+    save_json(STATE_PATH, state)
+
+def flat_str(x):
+    if isinstance(x, (list, tuple, set)):
+        return " ".join(flat_str(i) for i in x)
+    if isinstance(x, dict):
+        return " ".join(f"{k} {flat_str(v)}" for k, v in x.items())
+    return str(x)
+
+# ---------- load data ----------
+spec = load_yaml(SPEC_PATH, default={}) or {}
+kb   = load_yaml(KB_PATH, default={"knowledgebase": {}}) or {}
+kb   = kb.get("knowledgebase", {})
+state = load_state()
+
+uc = spec.get("ultimate_coder", {})
+tracks = uc.get("tracks", [])
+
+# ---------- UI ----------
+st.set_page_config(page_title="Ultimate Coder", layout="wide")
+st.title("🧭 Ultimate Coder – Control Panel")
+
+with st.sidebar:
+    st.header("Tracks & Modules")
+    track_titles = []
+    for t in tracks:
+        t_title = t.get("title") or t.get("id", "track")
+        t_id = t.get("id", t_title.lower().replace(" ", "_"))
+        track_titles.append((t_id, t_title, t))
+
+    # pick a track
+    track_label_map = {tid: ttl for tid, ttl, _ in track_titles}
+    choice_tid = st.selectbox("Select track", options=[tid for tid,_,_ in track_titles],
+                              format_func=lambda tid: track_label_map[tid])
+    active_track = next((t for tid,_,t in track_titles if tid == choice_tid), None)
+
+    st.markdown("---")
+    st.subheader("Quick Actions")
+    if st.button("Open Syllabus"):
+        (ROOT / "ultimate_coder" / "docs" / "syllabus.md").exists() and webbrowser.open_new_tab(
+            (ROOT / "ultimate_coder" / "docs" / "syllabus.md").as_uri()
+        )
+    if st.button("Open Knowledgebase YAML"):
+        KB_PATH.exists() and webbrowser.open_new_tab(KB_PATH.as_uri())
+
+# main columns
+col_left, col_right = st.columns([2, 1])
+
+# -------- LEFT: Modules of selected track --------
+with col_left:
+    if active_track:
+        st.subheader(f"📚 {active_track.get('title', active_track.get('id','Track'))}")
+        mods = active_track.get("modules", [])
+        for idx, m in enumerate(mods, start=1):
+            mod_name = m.get("name", f"Module {idx}")
+            mod_key = f"{active_track.get('id','track')}::{mod_name}"
+            with st.expander(f"{idx}. {mod_name}", expanded=False):
+                # meta
+                weeks = m.get("weeks")
+                skills = m.get("skills", [])
+                project = m.get("project") or m.get("exercise") or m.get("optional_lab", {}).get("title")
+                guardrails = m.get("guardrails", [])
+                assessment = m.get("assessment", {})
+
+                if weeks: st.markdown(f"**Weeks:** {weeks}")
+                if skills: st.markdown("**Skills:** " + ", ".join(map(str, skills)))
+                if project:
+                    st.markdown("**Project/Exercise:**")
+                    st.code(flat_str(project), language="text")
+
+                if guardrails:
+                    st.markdown("**Guardrails:**")
+                    for g in guardrails: st.write(f"- {g}")
+
+                if assessment:
+                    st.markdown("**Assessment/Rubric:**")
+                    st.code(yaml.safe_dump(assessment, sort_keys=False), language="yaml")
+
+                # progress + notes
+                done = state["completed"].get(mod_key, False)
+                new_done = st.checkbox("Mark complete", value=done, key=f"cb_{mod_key}")
+                if new_done != done:
+                    set_completed(state, mod_key, new_done)
+
+                note_val = state["notes"].get(mod_key, "")
+                new_note = st.text_area("Notes / links / todos", value=note_val, key=f"note_{mod_key}", height=120)
+                if new_note != note_val:
+                    set_note(state, mod_key, new_note)
+
+# -------- RIGHT: Knowledgebase search --------
+with col_right:
+    st.subheader("📚 Knowledgebase Search")
+    q = st.text_input("Search (e.g., 'Rust', 'SRE', 'OpenDSA')", "")
+    # flatten & filter
+    results = []
+    pattern = re.compile(re.escape(q), re.IGNORECASE) if q else None
+
+    for section, items in kb.items():
+        if isinstance(items, dict):
+            for sub, subitems in items.items():
+                lst = subitems if isinstance(subitems, list) else (subitems or [])
+                for it in lst:
+                    s = str(it)
+                    if not pattern or pattern.search(s):
+                        results.append((section, sub, s))
+        else:
+            # list form
+            for it in (items or []):
+                s = str(it)
+                if not pattern or pattern.search(s):
+                    results.append((section, None, s))
+
+    if q:
+        st.caption(f"{len(results)} result(s)")
+    else:
+        st.caption("Type to filter knowledgebase…")
+
+    for section, sub, item in results[:200]:
+        with st.container(border=True):
+            st.markdown(f"**{section}**" + (f" · _{sub}_" if sub else ""))
+            st.write(item)
+            # basic link detection
+            m = re.search(r"(https?://\S+)", item)
+            if m:
+                st.link_button("Open link", m.group(1))
+
+st.markdown("---")
+st.caption("Progress is saved to `ui/progress.json`. Edit YAML then refresh to see changes.")

--- a/ui/gradio_app.py
+++ b/ui/gradio_app.py
@@ -1,0 +1,42 @@
+import json, yaml
+from pathlib import Path
+import gradio as gr
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = yaml.safe_load((ROOT/"Codertext.yaml.txt").read_text("utf-8"))["ultimate_coder"]
+KB   = yaml.safe_load((ROOT/"ultimate_coder/resources/knowledgebase.yaml").read_text("utf-8"))["knowledgebase"]
+
+def list_modules(track_id):
+    for t in SPEC.get("tracks", []):
+        if t.get("id")==track_id:
+            return [m.get("name","module") for m in t.get("modules",[])]
+    return []
+
+def search_kb(q):
+    rows=[]
+    for sec, items in KB.items():
+        if isinstance(items, dict):
+            for sub, subitems in items.items():
+                for it in (subitems or []):
+                    if q.lower() in str(it).lower():
+                        rows.append((sec, sub, str(it)))
+        else:
+            for it in (items or []):
+                if q.lower() in str(it).lower():
+                    rows.append((sec, "", str(it)))
+    return rows
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Ultimate Coder – KB Browser")
+    tracks = [(t.get("title",t["id"]), t["id"]) for t in SPEC.get("tracks",[])]
+    tid = gr.Dropdown(choices=[v for _,v in tracks], label="Track")
+    out = gr.JSON(label="Modules")
+    btn = gr.Button("List Modules")
+    btn.click(lambda x: list_modules(x), tid, out)
+
+    gr.Markdown("## Knowledgebase Search")
+    q = gr.Textbox(label="Query")
+    res = gr.Dataframe(headers=["section","sub","item"], datatype=["str","str","str"])
+    q.change(lambda s: search_kb(s), q, res)
+
+demo.launch()


### PR DESCRIPTION
## Summary
- add Streamlit control panel to explore tracks, search the knowledgebase, and record progress
- provide optional Gradio browser, requirements file, and Makefile target
- validate both spec and knowledgebase YAML in CI and ignore local progress state

## Testing
- `python -m py_compile ui/app.py ui/gradio_app.py`
- `python -m pip install --quiet yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m pip install --quiet pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc04102b888324acd0840de1c155cb